### PR TITLE
React router implementation

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -3,6 +3,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from '../imports/containers/app.js';
 import { Provider } from 'react-redux'
+import {Router, Route, IndexRoute, browserHistory} from 'react-router';
 import store from '../imports/store';
 
 Accounts.ui.config({
@@ -11,6 +12,11 @@ Accounts.ui.config({
 
 Meteor.startup(() => {
   ReactDOM.render(
-    <Provider store={store}><App /></Provider>, 
+    <Provider store={store}>
+      <Router history={browserHistory}>
+        <Route path="/" component={App}>
+        </Route>
+      </Router>
+    </Provider>,
     document.getElementById('app'));
 });

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.5",
+    "react-router": "^2.4.1",
     "recompose": "^0.19.0",
     "redux": "^3.5.2",
     "redux-actions": "^0.9.1",


### PR DESCRIPTION
Actually there is only one path `localhost:3000/`, that load the App component.

To explore `react-router`, it's possible to implement the `/login`, `/register` path, implementing those actions in a - more - meteor-react-redux way; so to remove the blaze wrapper for the `account-ui` package.

What do you thik about?
